### PR TITLE
Disable health check logs

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,6 +10,12 @@ from app.config import log_config
 from app.config.settings import settings
 from kubernetes import config as kubernetes_config
 
+
+# Disable health check logs (https://stackoverflow.com/a/70810102)
+class EndpointFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.args and len(record.args) >= 3 and record.args[2] != "/health"
+
 app = FastAPI(title=settings.APP_NAME)
 app.include_router(apis.router)
 app.include_router(views.router)
@@ -18,6 +24,7 @@ app.mount("/static", StaticFiles(directory="app/static"), name="static")
 # Setup Logging
 dictConfig(log_config.logger_config)
 log = logging.getLogger(__name__)
+logging.getLogger("uvicorn.access").addFilter(EndpointFilter())
 
 # Connect to Kubernetes
 try:

--- a/task-scheduler.py
+++ b/task-scheduler.py
@@ -11,6 +11,13 @@ from app.config import log_config
 from app.config.settings import settings
 from kubernetes import config as kubernetes_config
 
+
+# Disable health check logs (https://stackoverflow.com/a/70810102)
+class EndpointFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return record.args and len(record.args) >= 3 and record.args[2] != "/health"
+
+
 app = FastAPI(title=settings.SCHEDULER_APP_NAME, on_startup=[load_cron_tasks])
 app.include_router(apis.router)
 app.include_router(views.router)
@@ -19,6 +26,7 @@ app.mount("/static", StaticFiles(directory="app/static"), name="static")
 # Setup Logging
 dictConfig(log_config.logger_config)
 log = logging.getLogger(__name__)
+logging.getLogger("uvicorn.access").addFilter(EndpointFilter())
 
 # Connect to Kubernetes
 try:


### PR DESCRIPTION
If application deployed with kubernetes readiness probe, the log output will be spammed by `"GET /health HTTP/1.1"` string. Which is not very useful and only complicates the debugging.  
![image](https://user-images.githubusercontent.com/24387396/194769637-749e7fd1-97eb-4542-9ff8-67cd41b7c459.png)
