### PR TITLE
make ss58_format mandatory option for collator register/deregister

### DIFF
--- a/app/lib/collator_manager.py
+++ b/app/lib/collator_manager.py
@@ -46,7 +46,7 @@ def get_collator_status(node_account, invulnerables, candidates):
 
 
 # map register function with network type
-async def collator_register(chain, node_name):
+async def collator_register(chain, node_name, ss58_format):
     if chain.startswith("moon"):
         log.info('Detected that collators are moon-based {}'.format(chain))
         return register_moon_collator(node_name)
@@ -55,13 +55,13 @@ async def collator_register(chain, node_name):
         return register_tick_collator(node_name)
     elif chain.endswith("mint") or chain.endswith("mine"):
         log.info('Detected that collators are mint-based {}'.format(chain))
-        return register_mint_collator(node_name)
+        return register_mint_collator(node_name, ss58_format)
     else:
         log.error('Only registration of moon-based, tick, statemint, statemine chains are supported! Chain:{}'.format(chain))
         return None
 
 
-async def collator_deregister(chain, node_name):
+async def collator_deregister(chain, node_name, ss58_format):
     if chain.startswith("moon"):
         log.info('Detected that collators are moon-based {}'.format(chain))
         # todo implement https://docs.moonbeam.network/node-operators/networks/collators/activities/#stop-collating
@@ -73,7 +73,7 @@ async def collator_deregister(chain, node_name):
         return None
     elif chain.endswith("mint") or chain.endswith("mine"):
         log.info('Detected that collators are mint-based {}'.format(chain))
-        return deregister_mint_collator(node_name)
+        return deregister_mint_collator(node_name, ss58_format)
     else:
         log.error('Only deregistration of moon-based, tick, statemint, statemine chains are supported! Chain:{}'.format(chain))
         return None

--- a/app/lib/collator_mint.py
+++ b/app/lib/collator_mint.py
@@ -12,14 +12,14 @@ from app.lib.node_utils import inject_key
 log = logging.getLogger('collator_mint')
 
 
-def register_mint_collator(node_name, ss58_format=0, rotate_key=False):
+def register_mint_collator(node_name, ss58_format, rotate_key=False):
     try:
         # 1. Generating stash account keypair
         node_client = get_node_client(node_name)
         collator_root_seed = network_validators_root_seed()
         collator_aura_key = collator_root_seed + "//collator//" + node_name
-        keypair_rich = Keypair.create_from_uri(collator_root_seed, ss58_format=ss58_format)
-        keypair = Keypair.create_from_uri(collator_aura_key, ss58_format=ss58_format)
+        keypair_rich = Keypair.create_from_uri(collator_root_seed, ss58_format=int(ss58_format))
+        keypair = Keypair.create_from_uri(collator_aura_key, ss58_format=int(ss58_format))
         candidates = node_client.query('CollatorSelection', 'Candidates').value
 
         if not any(d['who'].lower() == keypair.ss58_address.lower() for d in candidates) or rotate_key:
@@ -93,11 +93,11 @@ def register_mint_collator(node_name, ss58_format=0, rotate_key=False):
         return None
 
 
-def deregister_mint_collator(node_name, ss58_format=0):
+def deregister_mint_collator(node_name, ss58_format):
     node_client = get_node_client(node_name)
     collator_root_seed = network_validators_root_seed()
     collator_aura_key = collator_root_seed + "//collator//" + node_name
-    keypair = Keypair.create_from_uri(collator_aura_key, ss58_format=ss58_format)
+    keypair = Keypair.create_from_uri(collator_aura_key, ss58_format=int(ss58_format))
     try:
         candidates = node_client.query('CollatorSelection', 'Candidates').value
         if any(d['who'].lower() == keypair.ss58_address.lower() for d in candidates):

--- a/app/routers/apis.py
+++ b/app/routers/apis.py
@@ -124,7 +124,8 @@ async def register_collators(
         asyncio.create_task(register_statefulset_collators(para_id, statefulset))
     if node:
         chain = get_substrate_node(node[0])["chain"]
-        asyncio.create_task(register_collator_nodes(chain, node))
+        ss58_format = get_substrate_node(node[0])["ss58_format"]
+        asyncio.create_task(register_collator_nodes(chain, node, ss58_format))
 
 
 @router.post("/deregister_collators/{para_id}")
@@ -137,4 +138,5 @@ async def deregister_collators(
         asyncio.create_task(deregister_statefulset_collators(para_id, statefulset))
     if node:
         chain = get_substrate_node(node[0])["chain"]
-        asyncio.create_task(deregister_collator_nodes(chain, node))
+        ss58_format = get_substrate_node(node[0])["ss58_format"]
+        asyncio.create_task(deregister_collator_nodes(chain, node, ss58_format))


### PR DESCRIPTION
We have if case:
```
if not any(d['who'].lower() == keypair.ss58_address.lower() for d in candidates)
```
Which used to determent do we need to execute  register/deregister task. `candidates` map contains key in one `ss58_format ` and   `keypair.ss58_address` can use  another.  