### PR TITLE
Rewrite transfer_funds function

### DIFF
--- a/app/lib/balance_utils.py
+++ b/app/lib/balance_utils.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 from substrateinterface import Keypair
+from app.lib.substrate import substrate_batchall_call, substrate_call
 
 log = logging.getLogger('balance_utils')
 
@@ -21,51 +22,44 @@ def get_funds(substrate_client, address):
         return 0
 
 
-def transfer_funds(substrate_client, from_account_keypair, target_account_address, transfer_amount):
-    call = substrate_client.compose_call(
-        call_module='Balances',
-        call_function='transfer',
-        call_params={
-            'dest': target_account_address,
-            'value': transfer_amount
-        }
-    )
+def transfer_funds(substrate_client, from_account_keypair, target_account_address_list, transfer_amount):
+    batch_call = []
+    for address in target_account_address_list:
+        batch_call.append(substrate_client.compose_call(
+            call_module='Balances',
+            call_function='transfer',
+            call_params={
+                'dest': address,
+                'value': transfer_amount
+                }
+            )
+        )
 
-    extrinsic = substrate_client.create_signed_extrinsic(
-        call=call,
-        keypair=from_account_keypair
-    )
+    log.info(
+        "Sending {} from {} to {}".format(transfer_amount, from_account_keypair.ss58_address, target_account_address_list))
+    if len(batch_call) == 1:
+        receipt = substrate_call(substrate_client, from_account_keypair, batch_call[0])
+    else:
+        receipt = substrate_batchall_call(substrate_client, from_account_keypair, batch_call)
 
-    try:
-        old_balance = substrate_client.query('System', 'Account', params=[target_account_address]).value['data']['free']
-        log.info("Sending {} from {} to {}".format(transfer_amount, from_account_keypair.ss58_address, target_account_address))
-        receipt = substrate_client.submit_extrinsic(extrinsic, wait_for_inclusion=False)
-        log.info("Extrinsic '{}' sent".format(receipt.extrinsic_hash))
-        # todo: set wait_for_inclusion=False in submit_extrinsic after endpoint replaced to ws, and remove this wait.
-        # wait until balance changed
-        for i in range(30):
-            time.sleep(2)
-            new_fund = substrate_client.query('System', 'Account', params=[target_account_address]).value['data']['free']
-            if new_fund > old_balance:
-                log.info("New fund: {}".format(new_fund))
-                return new_fund
-        # timeout
-        log.error("Account {} did not receive fund, balance: {}. Error: Timeout".format(target_account_address, new_fund))
-        return new_fund
-
-    except Exception as e:
-        log.error("Failed to send fund from {} to {}. Error: {}".format(from_account_keypair.ss58_address,
-                                                                        target_account_address, e))
+    if receipt and receipt.is_success:
+        # return new_fund
+        return True
+    else:
+        log.error("Account {} did not receive fund, Extrinsic failed. Error: {}".format(
+            target_account_address_list, getattr(receipt, 'error_message', None)))
         return None
 
 
 def fund_accounts(substrate_client, addresses, funding_account_seed):
     funding_account_keypair = Keypair.create_from_seed(funding_account_seed)
+    target_account_address_list = []
     for address in addresses:
         address_funds = get_funds(substrate_client, address)
         log.info('address={} (funds={})'.format(address, address_funds))
         if address_funds < 0.5 * 10 ** 12:  # < 0.5 ROC
             log.info(
-                'address={} is not properly funded (funds={}), transferring funds from sudo account'.format(
+                'address={} is not properly funded (funds={}), schedule transferring funds from sudo account'.format(
                     address, address_funds))
-            transfer_funds(substrate_client, funding_account_keypair, address, 1 * 10**12)
+            target_account_address_list.append(address)
+    transfer_funds(substrate_client, funding_account_keypair, target_account_address_list, 1 * 10**12)

--- a/app/lib/collator_mint.py
+++ b/app/lib/collator_mint.py
@@ -31,7 +31,7 @@ def register_mint_collator(node_name, ss58_format, rotate_key=False):
             if account_info['data']['free'] < candidacy_bond + 0.1 * 10 ** 9:
                 print("Funding {}".format(keypair.ss58_address))
                 # candidacyBond + 1 tx fee
-                result = transfer_funds(node_client, keypair_rich, keypair.ss58_address, candidacy_bond + 1 * 10 ** 9)
+                result = transfer_funds(node_client, keypair_rich, [keypair.ss58_address], candidacy_bond + 1 * 10 ** 9)
                 if result == None:
                     # exit, failed to fund account
                     log.error("Unable fund account: {}, node: {}".format(

--- a/app/lib/collator_moonbeam.py
+++ b/app/lib/collator_moonbeam.py
@@ -50,7 +50,7 @@ def register_moon_collator(node_name, rotate_key=False):
         if account_info.value['data']['free'] < 1101 * 10 ** 18:
             log.info("Funding {}".format(keypair.ss58_address))
             # 1000 bound, 100 security deposit, 1 tx fee
-            transfer_funds(node_client, keypair_rich, keypair.ss58_address, 1101 * 10 ** 18)
+            transfer_funds(node_client, keypair_rich, [keypair.ss58_address], 1101 * 10 ** 18)
 
 
         # Join the Candidate Pool

--- a/app/lib/stash_accounts.py
+++ b/app/lib/stash_accounts.py
@@ -29,4 +29,4 @@ def get_account_funds(ws_endpoint, account_address):
 def fund_account(ws_endpoint, funding_account_seed, target_account_address):
     substrate_client = get_substrate_client(ws_endpoint)
     keypair = Keypair.create_from_seed(funding_account_seed)
-    transfer_funds(substrate_client, keypair, target_account_address, 1 * 10 ** 12)
+    transfer_funds(substrate_client, keypair, [target_account_address], 1 * 10 ** 12)

--- a/tests/balance_utils_test.py
+++ b/tests/balance_utils_test.py
@@ -21,7 +21,7 @@ class BalanceUtilsTest(unittest.TestCase):
 
         # Start Bob validator
         self.bob_validator = DockerContainer('parity/polkadot:latest')
-        self.bob_validator.with_command('--chain rococo-local --validator --bob --unsafe-ws-external --rpc-cors=all')
+        self.bob_validator.with_command('--chain rococo-local --validator --bob --unsafe-rpc-external --rpc-cors=all')
         self.bob_validator.with_exposed_ports(9933)
         self.bob_validator.start()
         self.bob_validator_http_url = 'http://{}:{}'.format(self.bob_validator.get_container_host_ip(),

--- a/tests/balance_utils_test.py
+++ b/tests/balance_utils_test.py
@@ -1,0 +1,73 @@
+import datetime
+import unittest
+
+from testcontainers.core.container import DockerContainer
+from substrateinterface import SubstrateInterface, Keypair
+
+from app.lib.balance_utils import get_funds, transfer_funds, fund_accounts
+from tests.test_utils import wait_for_http_ready
+
+
+class BalanceUtilsTest(unittest.TestCase):
+
+    def setUp(self):
+        # Start Alice validator
+        self.alice_validator = DockerContainer('parity/polkadot:latest')
+        self.alice_validator.with_command('--chain rococo-local --validator --alice --unsafe-ws-external --rpc-cors=all')
+        self.alice_validator.with_exposed_ports(9944)
+        self.alice_validator.start()
+        self.alice_validator_rpc_ws_url = 'ws://{}:{}'.format(self.alice_validator.get_container_host_ip(),
+                                                              self.alice_validator.get_exposed_port(9944))
+
+        # Start Bob validator
+        self.bob_validator = DockerContainer('parity/polkadot:latest')
+        self.bob_validator.with_command('--chain rococo-local --validator --bob --unsafe-ws-external --rpc-cors=all')
+        self.bob_validator.with_exposed_ports(9933)
+        self.bob_validator.start()
+        self.bob_validator_http_url = 'http://{}:{}'.format(self.bob_validator.get_container_host_ip(),
+                                                            self.bob_validator.get_exposed_port(9933))
+        # prepare keys
+        self.alice_key = '0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a'
+        self.alice_key_address = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
+        self.test_key_0_address = '5Gpg3hhPkyPRSwQc5EYprccoJ81fzEdUQqbtsY25RMezaPjb'
+        self.test_key_1_address = '5DMCAnbTJWDbB1bb91RCTmY5t9Ngie2m3LCakb2stmYUyByY'
+        self.test_key_2_address = '5GTn6hXhzRoEkEqWfJarWnjfVMMKcvzRrR85vhAxJmwepwbB'
+        self.test_key_3_address = '5G672AgoojLfkZyN8LkTqrGwwjM3ZsGhmg5t9DkUzFmaLeUN'
+        wait_for_http_ready(self.bob_validator_http_url + '/health')
+        self.substrate_client = SubstrateInterface(url=self.alice_validator_rpc_ws_url)
+
+    def tearDown(self):
+        self.alice_validator.stop()
+        self.bob_validator.stop()
+
+    def test_get_funds(self):
+        alice_keypair = Keypair.create_from_seed(self.alice_key)
+        funds = get_funds(self.substrate_client, alice_keypair.ss58_address)
+        print(funds)
+        self.assertEqual(funds, 1000000000000000000, 'Alice account have {} token'.format(funds))
+
+    def test_transfer_funds(self):
+        alice_keypair = Keypair.create_from_seed(self.alice_key)
+        new_fund = transfer_funds(self.substrate_client, alice_keypair, [self.test_key_0_address], 1000000000000)
+        print("new_fund", new_fund)
+        funds = get_funds(self.substrate_client, self.test_key_0_address)
+        print("funds", funds)
+        self.assertEqual(funds, 1000000000000, 'Alice account have {} token'.format(funds))
+
+    def test_fund_accounts(self):
+        print(datetime.datetime.now())
+        fund_accounts(
+            self.substrate_client,
+            [self.test_key_1_address, self.test_key_2_address, self.test_key_3_address],
+            self.alice_key
+        )
+        print(datetime.datetime.now())
+        fund1 = get_funds(self.substrate_client, self.test_key_1_address)
+        fund2 = get_funds(self.substrate_client, self.test_key_2_address)
+
+        print(fund1, fund2)
+        self.assertEqual(fund1, fund2, 'Alice account have {} token'.format(fund1))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes: https://github.com/paritytech/testnet-manager/issues/17

`fund_accounts` function was very slow it takes at least 6 sec to fund one account.  The new function uses `bacth_all` call and can fund all accounts in one call. I also replaced the `wait` loop with `wait_for_inclusion=true` parameter of the substrate call (`true` is the default value).

Speed improvements for 20 accounts:
before:
`~2min`
now:
`less than 6 sec`