### PR TITLE
Use bacthall for parachain onboarding

### DIFF
--- a/app/lib/network_utils.py
+++ b/app/lib/network_utils.py
@@ -16,7 +16,7 @@ from app.lib.node_utils import is_node_ready, \
 from app.lib.parachain_manager import get_parachain_id, get_all_parachain_lifecycles, \
     initialize_parachain, cleanup_parachain, get_parachain_wasm, get_parachain_head, get_parathreads_ids, \
     get_parachains_ids, get_all_parachain_leases_count, get_all_parachain_current_code_hashes, \
-    get_permanent_slot_lease_period_length, set_slot_lease, get_all_parachain_heads
+    get_permanent_slot_lease_period_length, get_all_parachain_heads
 from app.lib.session_keys import rotate_node_session_keys, set_node_session_key, get_queued_keys
 from app.lib.stash_accounts import get_derived_node_stash_account_address, get_node_stash_account_mnemonic
 from app.lib.substrate import get_relay_chain_client, get_node_client, substrate_rpc_request
@@ -470,13 +470,10 @@ async def onboard_parachain_by_id(para_id):
         wasm = get_parachain_wasm(para_node_client)
 
         if state and wasm:
-            log.info('Scheduling parachain #{}, state:{}, wasm: {}...{}'.format(para_id, state, wasm[0:64], wasm[-64:]))
-            initialize_parachain(relay_chain_client, sudo_seed, para_id, state, wasm)
             permanent_slot_lease_period_length = get_permanent_slot_lease_period_length(relay_chain_client)
-            log.info(
-                'Setting slot lease for parachain #{} to be valid for {} lease periods (permanent_slot_lease_period_length)'.format(
-                    para_id, permanent_slot_lease_period_length))
-            set_slot_lease(relay_chain_client, sudo_seed, para_id, permanent_slot_lease_period_length)
+            log.info('Scheduling parachain #{}, state:{}, wasm: {}...{}, lease: {}'.format(
+                para_id, state, wasm[0:64], wasm[-64:], permanent_slot_lease_period_length))
+            initialize_parachain(relay_chain_client, sudo_seed, para_id, state, wasm, permanent_slot_lease_period_length)
         else:
             log.error(
                 'Error: Not enough parameters to Scheduling parachain para_id: {}, state:{}, wasm: {}...{}'.format(

--- a/app/lib/substrate.py
+++ b/app/lib/substrate.py
@@ -68,7 +68,7 @@ def substrate_call(substrate_client, keypair, call, wait=True):
         return False
 
 
-def substrate_sudo_call(substrate_client, keypair, payload):
+def substrate_sudo_call(substrate_client, keypair, payload, wait=True):
     call = substrate_client.compose_call(
         call_module='Sudo',
         call_function='sudo',
@@ -76,10 +76,10 @@ def substrate_sudo_call(substrate_client, keypair, payload):
             'call': payload.value,
         }
     )
-    return substrate_call(substrate_client, keypair, call)
+    return substrate_call(substrate_client, keypair, call, wait)
 
 
-def substrate_batchall_call(substrate_client, keypair, batch_call, wait=True):
+def substrate_batchall_call(substrate_client, keypair, batch_call, wait=True, sudo=False):
     call = substrate_client.compose_call(
         call_module='Utility',
         call_function='batch',
@@ -87,7 +87,10 @@ def substrate_batchall_call(substrate_client, keypair, batch_call, wait=True):
             'calls': batch_call
         }
     )
-    return substrate_call(substrate_client, keypair, call, wait)
+    if sudo:
+        return substrate_sudo_call(substrate_client, keypair, call, wait)
+    else:
+        return substrate_call(substrate_client, keypair, call, wait)
 
 
 def substrate_query(substrate_client, module, function, params=[]):

--- a/tests/parachain_manager_test.py
+++ b/tests/parachain_manager_test.py
@@ -7,7 +7,7 @@ from testcontainers.compose import DockerCompose
 
 from app.lib.parachain_manager import get_parachain_head, get_parachain_wasm, initialize_parachain, cleanup_parachain, \
     get_parachains_ids, \
-    get_parathreads_ids, get_parachain_lifecycles, set_slot_lease, get_parachain_leases_count
+    get_parathreads_ids, get_parachain_lifecycles, get_parachain_leases_count
 
 
 # class ParachainManagerTest(unittest.TestCase):
@@ -77,8 +77,7 @@ from app.lib.parachain_manager import get_parachain_head, get_parachain_wasm, in
 #
 #     def test_set_force_slot_lease(self):
 #         para_id = 102
-#         initialize_parachain(self.relay_substrate, self.alice_key, para_id, '0x11', '0x11')
-#         set_slot_lease(self.relay_substrate, self.alice_key, para_id, 1)
+#         initialize_parachain(self.relay_substrate, self.alice_key, para_id, '0x11', '0x11', 1)
 #         leases_count = get_parachain_leases_count(self.relay_substrate, para_id)
 #         self.assertEquals(leases_count, 1, 'Slot lease set')
 #


### PR DESCRIPTION
Blocked by: https://github.com/paritytech/testnet-manager/pull/24

When we onboard multiple parachains  at once `lease_period`  is not set for all parachains. This PR will resolve this issue by batching `initialize_parachain` and `set_slot_lease` calls together. 

Registering the new parachains now will take less than 6 sec, before ~12sec. 