### PR TITLE
Small fixes for node_info page 

### DIFF
--- a/app/lib/network_utils.py
+++ b/app/lib/network_utils.py
@@ -535,7 +535,7 @@ def list_parachain_collators(para_id, stateful_set_name=''):
     collator_selection_invulnerables = []
     collator_selection_candidates = []
     collator_selection_desired_candidates = None
-    runtime = "?"
+    runtime = get_last_runtime_upgrade(parachain_node_client)
     try:
         # Get parachain staking pallet state for "moon*" chains
         if chain_name.startswith("moon"):
@@ -550,7 +550,6 @@ def list_parachain_collators(para_id, stateful_set_name=''):
         collator_selection_candidates = parachain_node_client.query('CollatorSelection', 'Candidates', params=[]).value
         collator_selection_desired_candidates = parachain_node_client.query('CollatorSelection', 'DesiredCandidates',
                                                                             params=[]).value
-        runtime = get_last_runtime_upgrade(parachain_node_client)
     except Exception as err:
         log.info(f'Unable to get collator set: {err}')
 

--- a/app/lib/stash_accounts.py
+++ b/app/lib/stash_accounts.py
@@ -23,7 +23,12 @@ def get_derived_node_stash_account_address(root_seed, node_name):
 
 
 def get_account_funds(ws_endpoint, account_address):
-    return substrate_query_url(ws_endpoint, 'System', 'Account', [account_address])['data']['free']
+    funds_data = substrate_query_url(ws_endpoint, 'System', 'Account', [account_address])['data']
+    # if account is not created the data is empty.
+    if 'free' in funds_data:
+        return funds_data['free']
+    else:
+        return None
 
 
 def fund_account(ws_endpoint, funding_account_seed, target_account_address):

--- a/local-kubernetes/Makefile
+++ b/local-kubernetes/Makefile
@@ -97,7 +97,7 @@ reload: build
 	@make web
 
 log:
-	@kubectl --context ${KUBERNETES_CONTEXT}  logs --tail 50 -f -l app.kubernetes.io/name=testnet-manager
+	@kubectl --context ${KUBERNETES_CONTEXT}  logs --tail 50 -f -l app.kubernetes.io/name=testnet-manager -n ${CHAIN_NAMESPACE}
 
 # ============================================================================================
 


### PR DESCRIPTION
## Changes

1. Runtime is not available in most parachains page, this is likely due to the use of `try-catch` statements.   I moved `get_last_runtime_upgrade` out from `try-catch`. This is safe since  `get_last_runtime_upgrade` already have `try-catch` statements inside function.  
2. If account not created the node page will fail:  
```
  File "/app/app/lib/stash_accounts.py", line 26, in get_account_funds
    return substrate_query_url(ws_endpoint, 'System', 'Account', [account_address])['data']['free']
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
TypeError: tuple indices must be integers or slices, not str

```
3. fix Makefile 