### PR TITLE
Add '/validators/register_inactive' cron job as api route

### DIFF
--- a/app/routers/apis.py
+++ b/app/routers/apis.py
@@ -135,7 +135,7 @@ async def register_inactive_validators():
         log.info("Executing register_inactive_validators task")
         asyncio.create_task(exec_cron_task(executable_task))
     else:
-        log.error('register_inactive_validators task not found')
+        raise HTTPException(status_code=404, detail='register_inactive_validators task not found')
     return PlainTextResponse('OK')
 
 @router.post("/rotate_session_keys")


### PR DESCRIPTION
I tested `curl` on `/tasks/list`, but this didn't return any jobs, so I went for the straight-forward solution and just added a new route in stead which triggers the calls in the right order.
