### PR TITLE
Validator view improvements for listing unknown validators

### DIFF
--- a/app/lib/network_utils.py
+++ b/app/lib/network_utils.py
@@ -86,7 +86,7 @@ def list_validators(stateful_set_name=''):
             if is_validator:
                 validators.append({'name': node_name, 'location': 'external', 'address': node_address,
                                    # 'funds': node_stash_account_funds,
-                                   'is_validator': is_validator, 'status': 'Running', 'version': '?'})
+                                   'is_validator': is_validator, 'status': '?', 'version': '?'})
 
     for pod in validator_pods:
         node_stash_account_address = get_validator_account_from_pod(pod)

--- a/app/lib/network_utils.py
+++ b/app/lib/network_utils.py
@@ -112,7 +112,7 @@ def list_validators(stateful_set_name=''):
                 is_validator = get_validator_status(validator_address, validator_set, validators_to_add,
                                                             validators_to_retire)
                 validators.append(
-                    {'name': 'unknown-validator-' + str(i), 'location': 'deleted_from_cluster',
+                    {'name': 'unknown-validator-' + str(i), 'location': 'unknown',
                      'address': validator_address,
                      # 'funds': node_stash_account_funds,
                      'is_validator': is_validator, 'status': 'Missing', 'version': '?'})

--- a/app/routers/views.py
+++ b/app/routers/views.py
@@ -56,10 +56,8 @@ async def validators(
         list(filter(lambda val: val['is_validator'] and val['location'] == 'in_cluster', validators)))
     inactive_validator_count = len(
         list(filter(lambda val: not val['is_validator'] and val['location'] == 'in_cluster', validators)))
-    deleted_validator_count = len(
+    unknown_validator_count = len(
         list(filter(lambda val: val['is_validator'] and val['location'] == 'deleted_from_cluster', validators)))
-    deleted_validators = list(filter(lambda val: val['is_validator'] and val['location'] == 'deleted_from_cluster', validators))
-    deleted_validator_addresses = list(map(lambda val: val['address'], deleted_validators))
 
     session_keys = get_session_queued_keys()
     for index in range(len(validators)):
@@ -72,10 +70,9 @@ async def validators(
                                                           'external_validator_count': external_validator_count,
                                                           'active_validator_count': active_validator_count,
                                                           'inactive_validator_count': inactive_validator_count,
-                                                          'deleted_validator_count': deleted_validator_count,
+                                                          'unknown_validator_count': unknown_validator_count,
                                                           'selected_stateful_set': statefulset,
                                                           'validator_stateful_sets': validator_stateful_sets,
-                                                          'deleted_validator_addresses': deleted_validator_addresses
                                                           })
 
 

--- a/app/templates/validators.html
+++ b/app/templates/validators.html
@@ -9,7 +9,7 @@
 {% if name_filter or address_filter or version_filter or location_filter or is_validator_filter %}
 <h3>Filter params: name={{ name_filter }}, address={{ address_filter }}, version={{ version_filter }}, location={{ location_filter }},is_validator={{ is_validator_filter }}</h3>
 {% else %}
-<h3>{{ network_name.capitalize() }} Validators : {{ external_validator_count }} Active in VM / {{ active_validator_count }} Active in K8S {% if inactive_validator_count %}/ {{ inactive_validator_count }} Inactive in K8S {% endif %}{% if deleted_validator_count %}/ {{ deleted_validator_count }} Deleted in K8S {% endif %}</h3>
+<h3>{{ network_name.capitalize() }} Validators : {{ external_validator_count }} External to K8S / {{ active_validator_count }} Active in K8S {% if inactive_validator_count %}/ {{ inactive_validator_count }} Inactive in K8S {% endif %}{% if unknown_validator_count %}/ {{ unknown_validator_count }} Unknown (external or deleted from K8S) {% endif %}</h3>
 {% endif %}
 <select id="statefulset_selection">
     <option value="/validators" {% if selected_stateful_set == '' %}selected{% endif %}>all</option>
@@ -21,9 +21,6 @@
 <button id="registerValidators" {% if selected_stateful_set == '' %}style="display: none"{% endif %}>Register</button>
 <button id="deregisterValidators" {% if selected_stateful_set == '' %}style="display: none"{% endif %}>Deregister</button>
 <button id="rotateSessionKeys">Rotate session keys</button>
-{% if deleted_validator_addresses %}
-<button id="deregisterDeletedValidators">Deregister Deleted validators</button>
-{% endif %}
 
 <table id="table" class="display compact" style="width:100%">
     <thead>
@@ -134,24 +131,6 @@
                     });
             }
         });
-
-        {% if deleted_validator_addresses %}
-        const deregisterDeletedValidatorsButton = document.querySelector("#deregisterDeletedValidators");
-        document.querySelector("#deregisterDeletedValidators").addEventListener("click", () => {
-            if (window.confirm(`Are you sure you want to deregister the following validators:\n{{ deleted_validator_addresses | join('\n') }}`)) {
-                deregisterDeletedValidatorsButton.disabled = true
-                fetch("/api/validators/deregister?address={{ deleted_validator_addresses | join('&address=') }}", {method: "POST"})
-                    .then(() => {
-                        deregisterDeletedValidatorsButton.textContent = "Deregistration in progress"
-                        deregisterDeletedValidatorsButton.style.backgroundColor = 'lightgreen'
-                    })
-                    .catch(error => {
-                        deregisterDeletedValidatorsButton.textContent = "Deregistration Failed: " + error
-                        deregisterDeletedValidatorsButton.style.backgroundColor = 'red'
-                    });
-            }
-        });
-        {% endif %}
     });
 </script>
 </body>

--- a/app/templates/validators.html
+++ b/app/templates/validators.html
@@ -44,12 +44,13 @@
         <tr>
             {% if validator.location == 'in_cluster' %}
             <td><a href="/nodes/{{ validator.name }}">{{ validator.name }}</a></td>
+            <td><a target="_blank" href="{{ node_logs_link | replace('{node}',validator.name) }}">🔎</a></td>
             {% else %}
+            <td>{{ validator.name }}/td>
             <td></td>
             {% endif %}
-            <td><a target="_blank" href="{{ node_logs_link | replace('{node}',validator.name) }}">🔎</a></td>
             <td>{{ validator.address }}</td>
-            <td><a target="_blank" href="https:/.subscan.io/account/{{ validator.address }}">🔗</a></td>
+            <td><a target="_blank" href="https://{{ network_name }}.subscan.io/account/{{ validator.address }}">🔗</a></td>
             <td>{{ validator.version }}</td>
             <td>{{ validator.status }}</td>
             <td>{{ validator.location }}</td>


### PR DESCRIPTION
In a testnet for which multiple organizations are running validators eg. Westend. It's important not to have the current "deregister deleted validator button" which would have the effect to deregister all unknown validators. This button functionality can now be easily performed with the API so it's no longer needed.