### PR TITLE
Add support of `checkVersion` in parachain_runtime_upgrade function

### DIFF
--- a/app/lib/parachain_manager.py
+++ b/app/lib/parachain_manager.py
@@ -192,12 +192,19 @@ def parachain_runtime_upgrade(runtime_name, para_id, runtime_wasm):
 
     log.info('Code hash: {}'.format(code_hash))
     # Construct parachainSystem.authorizeUpgrade(hash) call on the parachain and grab the encoded call
+    call_function_metadata = para_client.get_metadata_call_function("ParachainSystem", "authorize_upgrade")
+    if len(call_function_metadata['fields']) == 2:
+        call_params = {
+            'code_hash': code_hash,
+            # Since the authorization only has a hash, it cannot actually perform the verification.
+            'check_version': False
+        }
+    else:
+        call_params = {'code_hash': code_hash}
     call = para_client.compose_call(
         call_module='ParachainSystem',
         call_function='authorize_upgrade',
-        call_params={
-            'code_hash': code_hash
-        }
+        call_params=call_params
     )
     weight = get_query_weight(para_client, call)
     receipt = substrate_sudo_relay_xcm_call(para_id, call.encode(), weight)

--- a/app/lib/substrate.py
+++ b/app/lib/substrate.py
@@ -57,11 +57,11 @@ def get_query_weight(substrate_client, call):
 
 # Returns: {'weight': {'ref_time': 178260000, 'proof_size': 3593}, 'class': 'Normal', 'partialFee': 469298416}
 def get_query_info(substrate_client, call):
-    keypair = Keypair.create_from_mnemonic(Keypair.generate_mnemonic())
-    extrinsic = substrate_client.create_signed_extrinsic(call=call, keypair=keypair)
-    extrinsic_len = substrate_client.create_scale_object('u32')
-    extrinsic_len.encode(len(extrinsic.data))
     try:
+        keypair = Keypair.create_from_mnemonic(Keypair.generate_mnemonic())
+        extrinsic = substrate_client.create_signed_extrinsic(call=call, keypair=keypair)
+        extrinsic_len = substrate_client.create_scale_object('u32')
+        extrinsic_len.encode(len(extrinsic.data))
         return substrate_client.runtime_call("TransactionPaymentApi", "query_info", [extrinsic, extrinsic_len]).value
     except Exception as err:
         log.error(f'Failed to get query_info on {getattr(substrate_client, "url", "NO_URL")}; Error: {err}')


### PR DESCRIPTION
New parachain runtime has `checkVersion: bool` field:
![image](https://github.com/paritytech/testnet-manager/assets/24387396/04542a65-0b21-4c95-b731-e08ebb870bcb)
Old runtime: 
![image](https://github.com/paritytech/testnet-manager/assets/24387396/96651748-5603-44a6-b3b7-33c9fb5a841c)

## Changes
1. add support for `checkVersion`
2. fix `get_query_info` function (`shell` runtime fails on `create_signed_extrinsic` step. )