### PR TITLE
Add smoke test

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -1,0 +1,42 @@
+name: Run smoke test
+
+on: [push]
+
+
+jobs:
+  smoke_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+      - name:  Install minikube helmfile and plugins
+        run : |
+          curl -LO https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
+          install minikube-linux-amd64 /usr/local/bin/minikube
+          minikube version
+          HELMFILE_VERSION=0.153.1
+          curl -LO  https://github.com/helmfile/helmfile/releases/download/v${HELMFILE_VERSION}/helmfile_${HELMFILE_VERSION}_linux_amd64.tar.gz
+          tar -xzf helmfile_${HELMFILE_VERSION}_linux_amd64.tar.gz  -C /usr/local/bin/
+          helm plugin install https://github.com/databus23/helm-diff
+
+      - name: setup
+        run : |
+          cd local-kubernetes
+          make kube
+          make install
+          kubectl get pod -n rococo
+          kubectl wait --for=condition=Ready pods --all -n rococo --timeout=900s
+          kubectl get pod -n rococo
+
+      - name: Tests
+        run : |
+          pwd
+          (cd local-kubernetes && make web-ci)
+          pwd
+          ./tests/smoke_test.sh
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: web
+          path: output
+

--- a/app/routers/views.py
+++ b/app/routers/views.py
@@ -82,7 +82,7 @@ async def validators(
 async def parachains(
     request: Request
 ):
-    parachains = list_parachains().test
+    parachains = list_parachains()
     paras_count = len(parachains)
     parachain_count = len(list(filter(lambda para: para[1].get('lifecycle') == 'Parachain', parachains.items())))
     parathread_count = len(list(filter(lambda para: 'Parathread' in para[1].get('lifecycle', ''), parachains.items())))

--- a/app/routers/views.py
+++ b/app/routers/views.py
@@ -14,7 +14,9 @@ router = APIRouter()
 templates = Jinja2Templates(directory='app/templates')
 network = get_network()
 
+
 @router.get("/",  response_class=HTMLResponse, include_in_schema=False)
+@router.get("/index.html",  response_class=HTMLResponse, include_in_schema=False)
 async def homepage(request: Request):
     return templates.TemplateResponse('index.html', {'request': request, 'network': network})
 
@@ -80,7 +82,7 @@ async def validators(
 async def parachains(
     request: Request
 ):
-    parachains = list_parachains()
+    parachains = list_parachains().test
     paras_count = len(parachains)
     parachain_count = len(list(filter(lambda para: para[1].get('lifecycle') == 'Parachain', parachains.items())))
     parathread_count = len(list(filter(lambda para: 'Parathread' in para[1].get('lifecycle', ''), parachains.items())))

--- a/local-kubernetes/Makefile
+++ b/local-kubernetes/Makefile
@@ -2,7 +2,7 @@
 # Validator-manager Quick Deploy Makefile for Development and Testing
 # ============================================================================================
 
-KUBERNETES_CONTEXT = rancher-desktop #  minikube or rancher-desktop
+KUBERNETES_CONTEXT = minikube #  minikube or rancher-desktop
 # rococo or wococo (don't put space at the end of the variable it will be used as is)
 CHAIN_NAMESPACE = rococo
 
@@ -18,7 +18,7 @@ kube: kube_${KUBERNETES_CONTEXT}
 kube_minikube:
 	@minikube start \
 		--addons ingress --addons metrics-server --addons registry --driver docker \
-		--kubernetes-version=1.23.3 --memory=8g --cpus=4
+		--kubernetes-version=1.23.3 --memory=6g --cpus=2
 
 kube_minikube-podman:
 	@minikube start \
@@ -80,20 +80,23 @@ web-tasks:
 	@xdg-open 'http://localhost:8081/tasks'
 	@kubectl --context ${KUBERNETES_CONTEXT} port-forward service/testnet-manager-task-scheduler 8081:80 -n ${CHAIN_NAMESPACE}
 
+web-ci:
+	kubectl --context ${KUBERNETES_CONTEXT} port-forward service/testnet-manager 8080:80 -n ${CHAIN_NAMESPACE} &
+	timeout 30 sh -c 'until nc -z 127.0.0.1  8080; do sleep 1; echo -n .; done'
+
 # ============================================================================================
 
 apply: check
 	@helmfile --file ./charts/helmfile-${CHAIN_NAMESPACE}.yaml apply
-	@kubectl --context ${KUBERNETES_CONTEXT} delete pod  -l app.kubernetes.io/name=testnet-manager -n ${CHAIN_NAMESPACE}
-	@kubectl --context ${KUBERNETES_CONTEXT} delete pod  -l app.kubernetes.io/name=testnet-manager-task-scheduler -n ${CHAIN_NAMESPACE} # force recreate testnet-manager pod
 
-install: build setup apply
+install: setup build apply
 
 # ============================================================================================
 
 reload: build
 	@kubectl --context ${KUBERNETES_CONTEXT} delete pod  -l app.kubernetes.io/name=testnet-manager -n ${CHAIN_NAMESPACE}
-	@kubectl --context ${KUBERNETES_CONTEXT} delete pod  -l app.kubernetes.io/name=testnet-manager-task-scheduler -n ${CHAIN_NAMESPACE}
+	@kubectl --context ${KUBERNETES_CONTEXT} delete pod  -l app.kubernetes.io/name=testnet-manager-task-scheduler -n ${CHAIN_NAMESPACE} # force recreate testnet-manager pod
+	@make log &
 	@make web
 
 log:

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+
+# Usage:
+# kubectl --context minikube  port-forward service/testnet-manager 8080:80 -n rococo
+# ./smoke_test.sh
+
+ROUTE='index.html
+nodes
+nodes/localrococo-bootnode-0
+nodes/localrococo-moonbase-alice-node-0
+nodes/localrococo-shell-collator-node-0
+nodes/localrococo-statemint-alice-node-0
+validators
+parachains
+parachains/1000/runtime
+parachains/1001/runtime
+collators/1000
+collators/1001
+runtime
+'
+
+for path in $ROUTE;
+do
+  echo "/$path"
+  curl -f http://localhost:8080/$path --create-dirs -O --output-dir ./output
+done
+
+find ./output -type f -not -name "*.html" -exec mv {} {}.html \;

--- a/tests/smoke_test.sh
+++ b/tests/smoke_test.sh
@@ -22,7 +22,7 @@ runtime
 for path in $ROUTE;
 do
   echo "/$path"
-  curl -f http://localhost:8080/$path --create-dirs -O --output-dir ./output
+  curl --fail --silent --show-error http://localhost:8080/$path --create-dirs --remote-name --output-dir ./output
 done
 
 find ./output -type f -not -name "*.html" -exec mv {} {}.html \;


### PR DESCRIPTION
Added smoke test to ensure that all testnet-manager links are working.

## How it works?
1. CI starts minikube  and deploy example setup from `local-kubernetes` folder.
2. Run `smoke_test.sh` script which opens links  in testnet-manager 
3. if page is not working the CI will fail, for example [jobs#8921387934](https://github.com/paritytech/testnet-manager/actions/runs/4983838146/jobs/8921387934)
4. If CI is successful the html files will be uploaded as artifacts (for example [artifacts](https://github.com/paritytech/testnet-manager/actions/runs/4983946977)).  

## Future Improvements 
HTML files in artifacts should be available for preview, but for security reasons, it is not possible to open html page on github.com (html page may contain a script that will be executed).  We need to upload them to separate places and post links in PR comments.    