### PR TITLE
Fix test CI issue in docker-compose

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
           virtualenvs-in-project: true
       - name: Run tests
         run : |
+          pip install pyyaml==5.3.1
           pip install docker-compose
           poetry install --no-interaction --no-ansi
           docker-compose version


### PR DESCRIPTION
docker-compose v1 is not supported and causing conflict with latest pyyaml. The workaround until we migrate to v2 is to use a pyyaml 5.3.1.