### PR TITLE
Fix http protocol prefix returned in node_http_endpoint

### DIFF
--- a/app/config/network_configuration.py
+++ b/app/config/network_configuration.py
@@ -44,7 +44,7 @@ def node_http_endpoint(node_name):
         return node_http_pattern.replace("NODE_NAME", node_name)
     else:
         node_http_pattern = get_var_from_env('RPC_NODE_URL_PATTERN')
-        return f'ws://{node_http_pattern.replace("NODE_NAME", node_name)}'
+        return f'http://{node_http_pattern.replace("NODE_NAME", node_name)}'
 
 # Retain WS endpoint until HTTP RPC is completely removed
 def node_ws_endpoint(node_name):


### PR DESCRIPTION
Rotate key operations was erroneously attempted on `ws://versi-validator-a-node-11.versi:9944` but it is using HTTP and not WS.