### PR TITLE
fix get_derived_collator_session_keys

### DIFF
--- a/app/lib/collator_account.py
+++ b/app/lib/collator_account.py
@@ -33,7 +33,7 @@ def get_derived_collator_session_keys(node_name):
     except Exception as e:
         log.error("Unable to get_derived_collator_session_keys. Error: {}, stacktrace:\n".format(e, traceback.print_exc()))
         return {
-            'aura': None
+            'aura': '0x' + get_derived_collator_keypair(node_name).public_key.hex()
         }
 
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -14,7 +14,8 @@ services:
       - "9944"
     volumes: *chainspec
     depends_on: &depends_on_chainspec
-      - chainspec
+      chainspec:
+        condition: service_completed_successfully
     command: >
       --chain=/chainspec/rococo-local.json
       --rpc-port 9944


### PR DESCRIPTION
fix for: https://github.com/paritytech/testnet-manager/issues/114


## Changes
1. if rpc `generate_session_keys` is not available return the most common key `SR25519`
2. fix test 