### PR TITLE
session_keys: offline author_insertKey path for pre-#1739 node binaries

### DIFF
--- a/app/lib/network_utils.py
+++ b/app/lib/network_utils.py
@@ -23,7 +23,8 @@ from app.lib.parachain_manager import get_parachain_id, get_all_parachain_lifecy
     initialize_parachain, cleanup_parachain, get_chain_wasm, get_parachain_head, get_parathreads_ids, \
     get_parachains_ids, get_all_parachain_leases_count, get_all_parachain_current_code_hashes, \
     get_permanent_slot_lease_period_length, get_all_parachain_heads, get_parachain_node_client
-from app.lib.session_keys import rotate_node_session_keys, set_node_session_key, get_queued_keys
+from app.lib.session_keys import rotate_node_session_keys, set_node_session_key, get_queued_keys, \
+    generate_and_insert_session_keys
 from app.lib.stash_accounts import get_derived_node_stash_account_address, get_node_stash_account_mnemonic, \
     get_account_funds
 from app.lib.substrate import get_relay_chain_client, get_node_client, substrate_rpc_request
@@ -271,6 +272,11 @@ async def setup_validators_session_keys(node_name):
         # SCALE-encoded account id = the raw 32-byte public key (polkadot-sdk#1739).
         owner = '0x' + Keypair.create_from_uri(node_stash_account_mnemonic).public_key.hex()
         node_session_key = rotate_node_session_keys(node_endpoint, owner=owner)
+        if not node_session_key:
+            # Node whose generate_session_keys traps (stable2512 on a post-#1739
+            # runtime): insert keys + build the proof offline instead.
+            log.warning("RPC key rotation failed on {}; trying offline author_insertKey path".format(node_name))
+            node_session_key = generate_and_insert_session_keys(node_endpoint, node_stash_account_mnemonic)
         # If rotate_key result from node is not empty, set session key and mark account to be registered
         if node_session_key:
             log.info("Setting session key for {} ({})".format(stash_account_address, node_session_key['keys']))
@@ -348,7 +354,13 @@ async def register_validator_pods(pods):
             log.info(f'Rotate node session keys for {node}')
             rotated = rotate_node_session_keys(node_http_endpoint(node), owner=owner)
             if not rotated:
-                log.error(f'Fail to set up PoS Validator: {node} (session key rotation failed)')
+                # A node whose `generate_session_keys` runtime API traps (e.g. a
+                # stable2512 binary on a post-#1739 runtime) can't rotate; fall back
+                # to inserting deterministic keys and building the proof offline.
+                log.warning(f'RPC key rotation failed for {node}; trying offline author_insertKey path')
+                rotated = generate_and_insert_session_keys(node_http_endpoint(node), validator_stash_mnemonic)
+            if not rotated:
+                log.error(f'Fail to set up PoS Validator: {node} (could not obtain session keys)')
                 continue
 
             log.info(f'Registering PoS Validator: {node}')

--- a/app/lib/session_keys.py
+++ b/app/lib/session_keys.py
@@ -1,9 +1,30 @@
+import hashlib
 import logging
 import requests
-from substrateinterface import Keypair
+from eth_keys.datatypes import PrivateKey as EcdsaPrivateKey
+from substrateinterface import Keypair, KeypairType
 from app.lib.substrate import get_substrate_client, substrate_call
 
 log = logging.getLogger('session_keys')
+
+# Westend/versi `SessionKeys` in struct order, with each key's crypto scheme:
+# grandpa (ed25519), babe/para_validator/para_assignment/authority_discovery
+# (sr25519), beefy (ecdsa). The 4-byte key-type ids match the runtime's KeyTypeIds.
+_SESSION_KEY_SPECS = [
+    ("gran", KeypairType.ED25519),
+    ("babe", KeypairType.SR25519),
+    ("para", KeypairType.SR25519),
+    ("asgn", KeypairType.SR25519),
+    ("audi", KeypairType.SR25519),
+    ("beef", KeypairType.ECDSA),
+]
+
+# `sp_core::proof_of_possession` prefixes the owner with this 4-byte context tag.
+_POP_CONTEXT = b"POP_"
+
+
+def _blake2_256(data):
+    return hashlib.blake2b(data, digest_size=32).digest()
 
 
 # substrate_client must be connected to the node on which we want to run rotate_keys
@@ -49,6 +70,71 @@ def rotate_node_session_keys(node_http_endpoint, owner=None):
         return {'keys': result, 'proof': '0x'}
     except Exception as err:
         log.error("Failed to rotate key on {}; Error: {}".format(node_http_endpoint, err))
+        return ''
+
+
+def _pop_signature(key_type, crypto_type, seed_hex, private_seed, statement):
+    """Sign the proof-of-possession statement with one session key.
+
+    sr25519/ed25519 sign the raw statement (matches `sp_io::crypto`); ecdsa signs
+    `blake2_256(statement)` in the 65-byte r||s||recid form. NOTE:
+    `substrateinterface`'s `Keypair(ECDSA).sign` uses keccak, so we sign the ecdsa
+    key with `eth_keys` over the blake2 digest instead.
+    """
+    if crypto_type == KeypairType.ECDSA:
+        return EcdsaPrivateKey(private_seed).sign_msg_hash(_blake2_256(statement)).to_bytes()
+    kp = Keypair.create_from_seed(seed_hex, crypto_type=crypto_type)
+    return kp.sign(statement)
+
+
+def generate_and_insert_session_keys(node_http_endpoint, stash_seed):
+    """Offline session-key path for nodes whose `generate_session_keys` runtime API
+    traps (a stable2512 binary against a post-#1739 runtime, which changed that API
+    to v2). Derive the six session keys from deterministic seeds, insert each into
+    the node keystore via `author_insertKey` (which does NOT invoke the trapping
+    runtime API), and build the ownership proof offline (per-key signatures over the
+    `POP_`-tagged stash account id, concatenated in `SessionKeys` order).
+
+    Returns `{'keys': '0x..', 'proof': '0x..'}` or `''` on failure.
+    """
+    try:
+        stash = Keypair.create_from_uri(stash_seed)
+        owner = stash.public_key  # SCALE(AccountId32) == the raw 32-byte public key
+        statement = _POP_CONTEXT + owner
+
+        keys = b""
+        proof = b""
+        for key_type, crypto_type in _SESSION_KEY_SPECS:
+            # Deterministic per-(validator, key-type) raw seed. Raw seeds sidestep
+            # substrateinterface's ecdsa derivation only accepting BIP44 paths, and
+            # the node derives the same key from the same `0x`-seed SURI.
+            seed = _blake2_256(stash_seed.encode() + key_type.encode())
+            seed_hex = "0x" + seed.hex()
+
+            if crypto_type == KeypairType.ECDSA:
+                public = EcdsaPrivateKey(seed).public_key.to_compressed_bytes()  # 33 bytes
+            else:
+                public = Keypair.create_from_seed(seed_hex, crypto_type=crypto_type).public_key
+
+            resp = requests.post(node_http_endpoint, json={
+                "id": 1, "jsonrpc": "2.0", "method": "author_insertKey",
+                "params": [key_type, seed_hex, "0x" + public.hex()],
+            }, headers={'Content-type': 'application/json'}, timeout=10)
+            body = resp.json()
+            if resp.status_code != 200 or 'error' in body:
+                log.error("author_insertKey({}) failed on {}: {}".format(
+                    key_type, node_http_endpoint, body.get('error')))
+                return ''
+
+            keys += public
+            proof += _pop_signature(key_type, crypto_type, seed_hex, seed, statement)
+
+        log.info("{} session keys inserted offline (bypassing generate_session_keys)".format(
+            node_http_endpoint))
+        return {'keys': "0x" + keys.hex(), 'proof': "0x" + proof.hex()}
+    except Exception as err:
+        log.error("Offline session-key insertion failed on {}; Error: {}".format(
+            node_http_endpoint, err))
         return ''
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1962,4 +1962,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "0216455b519552d5e2ecca6854dabe2ec7c5d11579983c8ebd0dff90b852e086"
+content-hash = "a6fbdc51a5f7b6768edafbc9202034172fa56655921caf4bf1d3cf9191fd28ab"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ gunicorn = "^20.1.0"
 uvicorn = "^0.21.1"
 kubernetes = "^27.2.0"
 substrate-interface = "^1.7.9"
+# Direct dep (also pulled by substrate-interface): used for BEEFY/ecdsa
+# proof-of-possession signing over a blake2_256 prehash in the offline key path.
+eth-keys = "^0.5.1"
 Jinja2 = "^3.1.3"
 fastapi = "^0.109.1"
 python-multipart = "^0.0.7"

--- a/tests/session_keys_test.py
+++ b/tests/session_keys_test.py
@@ -4,7 +4,8 @@ import unittest
 from substrateinterface import Keypair
 from testcontainers.core.container import DockerContainer
 
-from app.lib.session_keys import rotate_node_session_keys, set_node_session_key
+from app.lib.session_keys import rotate_node_session_keys, set_node_session_key, \
+    generate_and_insert_session_keys
 from tests.test_constants import RPC_DEV_FLAGS
 from tests.test_utils import wait_for_http_ready
 
@@ -40,6 +41,16 @@ class NodeSessionKeysTest(unittest.TestCase):
                                       rotated['keys'], proof=rotated['proof'])
         print(result)
         self.assertTrue(result, 'SetKeys executed successfully on //Alice//stash')
+
+    def test_offline_session_keys_accepted_by_runtime(self):
+        # The offline path (author_insertKey + offline ownership proof) must produce
+        # a proof the post-#1739 runtime accepts in set_keys — end-to-end proof that
+        # the per-scheme signing (incl. the ecdsa/beefy blake2 prehash) is correct.
+        inserted = generate_and_insert_session_keys(self.polkadot_rpc_http_url, '//Alice//stash')
+        self.assertTrue(inserted, "Offline key insertion succeeded")
+        result = set_node_session_key(self.polkadot_rpc_ws_url, '//Alice//stash',
+                                      inserted['keys'], proof=inserted['proof'])
+        self.assertTrue(result, 'set_keys accepts the offline-generated ownership proof')
 
     def test_rotate_node_session_keys_bad_url(self):
         session_key = rotate_node_session_keys('http://localhost:1234', owner=_owner('//Alice//stash'))


### PR DESCRIPTION
A stable2512 node cannot generate session keys against versi's post-#1739 runtime: the SessionKeys API changed v1->v2, so the node's v1 generate_session_keys call decodes wrong and traps (wasm unreachable), which TM's rotate RPC cannot work around.

Add an offline path that bypasses that runtime API: derive the six SessionKeys from deterministic raw seeds, insert each into the node keystore via author_insertKey, and build the ownership proof offline - per-key signatures over the POP_-tagged stash account id, concatenated in SessionKeys order. sr25519/ed25519 sign the raw statement; the ecdsa/beefy key signs blake2_256(statement) via eth_keys (substrateinterface's ecdsa sign uses keccak). Raw seeds avoid substrateinterface's ecdsa derivation only accepting BIP44 paths, and the node derives the same key from the same 0x-seed SURI.

Both registration flows fall back to this path when RPC rotation fails. Validated end-to-end: a post-#1739 runtime's set_keys accepts the offline proof (new test).