### PR TITLE
fix(validators): attribute genesis-authority pods by session keys

### DIFF
--- a/app/lib/network_utils.py
+++ b/app/lib/network_utils.py
@@ -110,18 +110,56 @@ def list_validators(stateful_set_name=''):
         for validator in validators:
             if validator['is_validator']:
                 known_validators_addresses.append(validator['address'])
+        unclaimed_addresses = [address for address in validator_set
+                               if address not in known_validators_addresses]
+
+        # Before declaring these addresses unknown, try to attribute each one to an
+        # in-cluster pod by checking which node holds the session keys registered
+        # on-chain for it. This covers validators whose stash account is not derived
+        # from the pod name (e.g. genesis authorities such as bootnodes) and which
+        # don't carry a validatorAccount label.
+        if unclaimed_addresses:
+            queued_session_keys = get_queued_keys(get_relay_chain_client())
+            unmatched_pod_validators = [validator for validator in validators
+                                        if validator['location'] == 'in_cluster' and not validator['is_validator']]
+            for validator_address in list(unclaimed_addresses):
+                account_session_keys = queued_session_keys.get(validator_address)
+                if not account_session_keys:
+                    continue
+                for validator in unmatched_pod_validators:
+                    if node_has_session_keys(validator['name'], account_session_keys):
+                        log.info('matched validator address {} to pod {} via session keys'.format(
+                            validator_address, validator['name']))
+                        validator['address'] = validator_address
+                        validator['is_validator'] = get_validator_status(validator_address, validator_set,
+                                                                         validators_to_add, validators_to_retire)
+                        unclaimed_addresses.remove(validator_address)
+                        unmatched_pod_validators.remove(validator)
+                        break
+
         i = 0
-        for validator_address in validator_set:
-            if not validator_address in known_validators_addresses:
-                is_validator = get_validator_status(validator_address, validator_set, validators_to_add,
-                                                            validators_to_retire)
-                validators.append(
-                    {'name': 'unknown-validator-' + str(i), 'location': 'unknown',
-                     'address': validator_address,
-                     # 'funds': node_stash_account_funds,
-                     'is_validator': is_validator, 'status': 'Missing', 'version': '?'})
-                i = i + 1
+        for validator_address in unclaimed_addresses:
+            is_validator = get_validator_status(validator_address, validator_set, validators_to_add,
+                                                        validators_to_retire)
+            validators.append(
+                {'name': 'unknown-validator-' + str(i), 'location': 'unknown',
+                 'address': validator_address,
+                 # 'funds': node_stash_account_funds,
+                 'is_validator': is_validator, 'status': 'Missing', 'version': '?'})
+            i = i + 1
     return validators
+
+
+def node_has_session_keys(node_name, account_session_keys):
+    try:
+        node_client = get_node_client(node_name)
+        if not node_client:
+            return False
+        has_keys = check_has_session_keys(node_client, account_session_keys)
+        return bool(has_keys) and all(has_keys.values())
+    except Exception as err:
+        log.warning('failed to check session keys on {}: {}'.format(node_name, err))
+        return False
 
 
 def get_node_info_from_pod(pod):

--- a/app/routers/views.py
+++ b/app/routers/views.py
@@ -60,7 +60,7 @@ async def validators(
     inactive_validator_count = len(
         list(filter(lambda val: not val['is_validator'] and val['location'] == 'in_cluster', validators)))
     unknown_validator_count = len(
-        list(filter(lambda val: val['is_validator'] and val['location'] == 'deleted_from_cluster', validators)))
+        list(filter(lambda val: val['is_validator'] and val['location'] == 'unknown', validators)))
 
     session_keys = get_session_queued_keys()
     for index in range(len(validators)):


### PR DESCRIPTION
## Problem

On deployments where bootnodes run as genesis authorities (e.g. Versi), the `/validators` page shows each such node twice, both times wrong:

- The bootnode pod row displays a stash address that exists nowhere on chain. Authority pods without a `validatorAccount` label get their address derived as `DERIVATION_ROOT_SEED//<pod-name>//stash`, which is wrong for validators whose stash account was baked into the chainspec rather than derived from the pod name.
- The node's *real* validator-set address is then claimed by no row and surfaces as `unknown-validator-N` with status "Missing".

## Fix

Before creating `unknown-validator-N` rows, `list_validators` now tries to attribute each unclaimed validator-set address to an in-cluster pod:

1. Fetch the on-chain session keys for active validators in one `Session.QueuedKeys` query.
2. For each unclaimed address, ask each still-unmatched authority pod via `author_hasKey` whether its keystore holds **all** of that address's registered session keys (reusing the existing `check_has_session_keys` helper).
3. On a match, the pod row gets the real on-chain address and its validator status is recomputed; anything still unmatched falls through to the `unknown-validator-N` rows exactly as before.

The node RPC is wrapped in a defensive `node_has_session_keys` helper: unreachable nodes, `None` clients, or unexpected key types in the runtime's `SessionKeys` struct log a warning and count as "no match" instead of breaking the page. The correlation only runs when unclaimed addresses exist, and is bounded by (unclaimed addresses × unmatched pods × key types) local RPC calls.

Also fixes the header's unknown-validator count: unknown rows are created with `location: 'unknown'`, but the counter filtered on `'deleted_from_cluster'`, so it always displayed 0.

Note: setting the `validatorAccount` extraLabel on the bootnode helm releases (as `local-kubernetes/charts/helmfile-rococo.yaml` does for the local Alice/Bob bootnodes) remains the proper deployment-side fix; with the label present the new correlation path never needs to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)